### PR TITLE
#16 feat: scroll animation homepage

### DIFF
--- a/squadpage/src/routes/+page.svelte
+++ b/squadpage/src/routes/+page.svelte
@@ -67,7 +67,7 @@
     }
 
     @media (prefers-reduced-motion: no-preference) {
-    .squadpage::before {
+    .squadpage::before { /* https://scroll-driven-animations.style/demos/progress-bar/css/*/
         content: '';
         height: .6em;
         position: fixed;
@@ -142,7 +142,24 @@
       gap: clamp(1rem, 2.5vw, 2rem);
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     }
-  
+    
+    @media (prefers-reduced-motion: no-preference) {
+      .students-grid { 
+          animation: fade-in linear;
+          animation-timeline: view();  /*animatie begint bij het verschijnen in de viewport*/   
+          animation-range: entry;
+      }
+
+      @keyframes fade-in { /*scroll driven animations*/
+        0% {
+        opacity: 0;
+        }
+      
+        100% {
+        opacity: 1;
+      }
+    }
+  }
     .card {
       background: var(--card-color);
       border: 1px solid #ddd;


### PR DESCRIPTION

#### Wat is er veranderd in de commit?
- Scroll driven animation toegevoegd bij de cards
- De cards veranderen van opacity bij het scrollen:
```CSS
 @keyframes fade-in { /*scroll driven animations*/
        0% {
        opacity: 0;
        }
      
        100% {
        opacity: 1;
      }
    }
```

#### Wat moet er gereviewd worden?

- [x] Feedback op de keuze op de cards een lage opacity te geven en na het scrollen de cards zichtbaarder worden
- [x] Ik twijfel over een scroll animatie op de detailpagina. Zou op de detailpagina ook een scroll animatie passen? Laat me weten wat je van dit idee vindt.


#### Images

https://github.com/user-attachments/assets/8a342630-e627-4520-b0ce-c639784684b1
