### PR TITLE
Fix: RAPPE check: responsive

### DIFF
--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -18,7 +18,7 @@
         </a>
 
         <button class="menu" on:click={() => menuOpen = true}> <!-- open menu button -->
-            <img src={menuIcon} alt="menu icon" width="60" height="60">
+            <img class="menu-icon" src={menuIcon} alt="menu icon">
             <span>Menu</span>
         </button>
 
@@ -71,30 +71,42 @@
     }
 
     .squadpage-img {
-        @media (min-width: 368px) {
-            width: 20em;
+        @media (min-width: 300px) {
+            width: 15em;
+            height: 5em;
         }
 
         @media (min-width: 724px) {
-            width: 38em;
+            width: 40em;
+            height: 10em;
         }
     }
 
-    .menu{
+    .menu {
         display: flex;
         align-items: center;
         gap: .2em;
         flex-direction: column;
         position: absolute;
-        top: .5em;
+        top: 1.9em;
         right: 1.5em;
         cursor: pointer;
+        font-size: var(--font-size-menu);
         @media (min-width: 724px) {
             top: 1.5em;
+            font-size: var(--font-size-small);
         }
         
     }
 
+    .menu-icon {
+        width: 2em;
+        height: 2em;
+        @media (min-width: 724px) {
+            width: 3em;
+            height: 3em;
+        }
+    }
     .button-close-menu {
         display: flex;
         align-items: center;
@@ -118,7 +130,7 @@
         right: 0;
         top: -2em;
         bottom: -2em;
-        translate: -100% 0%; /* verberg menu buiten scherm */
+        translate: -120% 0%; /* verberg menu buiten scherm */
         transition: translate .3s;
         background-color: var(--background-color);
         z-index: 1;

--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -27,11 +27,11 @@
             <ul class="navigation" class:open={menuOpen}> <!-- navigation menu, class 'open' toegevoegd als menuOpen true is -->
 
                 <button class="button-close-menu" on:click={() => menuOpen = false}> <!-- close menu button -->
-                    <img src={menuIcon} alt="close menu icon" width="60" height="60">
+                    <img class="image-close-menu" src={menuIcon} alt="close menu icon">
                     <span>Sluit</span>
                 </button>
 
-                <img class="menu-image" src={menu} alt="svg of a menu text" width="400">
+                <img class="menu-image" src={menu} alt="svg of a menu text">
 
                 <img class="flower-image" src={flowers} alt="svg of a flowers" width="350">
 
@@ -91,7 +91,6 @@
         top: 1.9em;
         right: 1.5em;
         cursor: pointer;
-        font-size: var(--font-size-menu);
         @media (min-width: 724px) {
             top: 1.5em;
             font-size: var(--font-size-small);
@@ -107,6 +106,7 @@
             height: 3em;
         }
     }
+
     .button-close-menu {
         display: flex;
         align-items: center;
@@ -118,10 +118,21 @@
         cursor: pointer;
         }
 
+    .image-close-menu {
+        width: 2em;
+        height: 2em;
+        @media (min-width: 724px) {
+            width: 3em;
+            height: 3em;
+        }
+    }
+
     span{
         font-family: var(--font-regular);
-        font-size: var(--font-size-xsmall);
-
+        font-size: var(--font-size-menu);
+        @media (min-width: 724px) {
+            font-size: var(--font-size-xsmall);
+        }
     }
 
     .navigation {
@@ -144,21 +155,35 @@
     .menu-image {
         display: block;
         margin: 2em auto 0 auto;
+        width: 15em;
+        height: 5em;
+        @media (min-width: 724px) {
+            width: 40em;
+            height: 10em;
+        }
     }
    
    .flower-image {
         position: absolute;
         top: .7em;
         left: 0;
+        @media (min-width: 300px) {
+        height: 20em;
+        width: auto;
+        }
     }
 
     .navigation li {
         text-align: center;
         margin: 2em;
-        font-size: var(--font-size-medium);
+        font-size: var(--font-size-small);
         font-family: var(--font-regular);
         &:hover{
             text-decoration: underline;
+        }
+        
+        @media (min-width: 724px) {
+            font-size: var(--font-size-medium);
         }
     }
 

--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -31,9 +31,9 @@
                     <span>Sluit</span>
                 </button>
 
-                <img class="menu-image" src={menu} alt="svg of a menu text" width="400" height="auto">
+                <img class="menu-image" src={menu} alt="svg of a menu text" width="400">
 
-                <img class="flower-image" src={flowers} alt="svg of a flowers" width="350" height="auto">
+                <img class="flower-image" src={flowers} alt="svg of a flowers" width="350">
 
 
                 <li>

--- a/squadpage/src/routes/+page.svelte
+++ b/squadpage/src/routes/+page.svelte
@@ -45,6 +45,7 @@
       --text-color: black;
       --accent-color: #3b0764;
       --font-regular: 'Jacques Francois', sans-serif;
+      --font-size-menu: .75em;
       --font-size-xsmall: 1em;
       --font-size-small: 1.25em;
       --font-size-medium: 1.75em;

--- a/squadpage/src/routes/+page.svelte
+++ b/squadpage/src/routes/+page.svelte
@@ -17,10 +17,10 @@
 
   <nav class="squadpage-classes">
       <a href="/squad2e">
-          <img src={squad2e} alt="squad 2E icon" width="175" height="auto">
+          <img src={squad2e} alt="squad 2E icon" width="175" >
       </a>
       <a href="/squad2f">
-          <img src={squad2f} alt="squad 2F icon" width="175" height="auto">
+          <img src={squad2f} alt="squad 2F icon" width="175">
       </a>
     </nav>
 
@@ -130,6 +130,12 @@
       align-items: center;
       gap: clamp(1rem, 2vw, 2rem);
       background-color: var(--background-color);
+    }
+
+    .squadpage-classes {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   
     .students-grid {


### PR DESCRIPTION

## Wat is er veranderd in de commit?

- Responsiveness van header verbeterd met @media #36 #40 
- Responsiveness van de menu verbeterd


## Wat moet er gereviewd worden?

- [ ] We hebben een aantal feedback punten ontvangen van mede studenten. Zie je nog ergens punten in mobiel/desktop die beter kunnen?


## Images

### Before
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/4b6bcb36-1a06-4b84-885d-caad89030940" />

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/62243dc8-2389-4ac7-84ab-58004e6d04a0" />


### After
<img width="1084" height="575" alt="Scherm­afbeelding 2025-09-18 om 22 38 29" src="https://github.com/user-attachments/assets/b290677f-c181-475c-b8b0-5a79ca9d31b1" />

<img width="1084" height="495" alt="Scherm­afbeelding 2025-09-18 om 22 38 49" src="https://github.com/user-attachments/assets/aab72fb5-ab8e-472e-affd-8ccb5c45c7e5" />
