### PR TITLE
Alt attributen verbeterd #47

### DIFF
--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -18,7 +18,7 @@
         </a>
 
         <button class="menu" on:click={() => menuOpen = true}> <!-- open menu button -->
-            <img src={menuIcon} alt="menu icon" width="60" height="60">
+            <img src={menuIcon} alt="" width="60" height="60">
             <span>Menu</span>
         </button>
 
@@ -27,7 +27,7 @@
             <ul class="navigation" class:open={menuOpen}> <!-- navigation menu, class 'open' toegevoegd als menuOpen true is -->
 
                 <button class="button-close-menu" on:click={() => menuOpen = false}> <!-- close menu button -->
-                    <img src={menuIcon} alt="close menu icon" width="60" height="60">
+                    <img src={menuIcon} alt="sluit menu" width="60" height="60">
                     <span>Sluit</span>
                 </button>
 

--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -35,7 +35,7 @@
                     <img class="menu-image" src={menu} alt="Menu" width="400">
                 </h1>
 
-                <img class="flower-image" src={flowers} alt="svg of a flowers" width="350">
+                <img class="flower-image" src={flowers} alt="" width="350">
 
                 <li>
                     <a href="/">Home</a>

--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -14,7 +14,7 @@
     <nav>
 
         <a href="/">
-            <img class="squadpage-img" src={squadpage} alt="squadpage sketch">
+            <img class="squadpage-img" src={squadpage} alt="titelafbeelding van de squadpagina">
         </a>
 
         <button class="menu" on:click={() => menuOpen = true}> <!-- open menu button -->

--- a/squadpage/src/lib/components/Header.svelte
+++ b/squadpage/src/lib/components/Header.svelte
@@ -31,10 +31,11 @@
                     <span>Sluit</span>
                 </button>
 
-                <img class="menu-image" src={menu} alt="svg of a menu text" width="400" height="auto">
+                <h1>
+                    <img class="menu-image" src={menu} alt="Menu" width="400">
+                </h1>
 
-                <img class="flower-image" src={flowers} alt="svg of a flowers" width="350" height="auto">
-
+                <img class="flower-image" src={flowers} alt="svg of a flowers" width="350">
 
                 <li>
                     <a href="/">Home</a>

--- a/squadpage/src/routes/+page.svelte
+++ b/squadpage/src/routes/+page.svelte
@@ -28,10 +28,15 @@
       {#each members as member}
         <li>
           <article class="card">
+            
             <picture class="avatar">
               <img src={member.avatar ? member.avatar : avatar } alt={member.avatar ? `Github avatar van ${member.name}` : `Standaard avatar voor ${member.name}`} width="130" /> 
             </picture>
+
+            <h2>
               <a class="name" href={`/members/${member.id}`}>{member.name}</a>
+            </h2>
+
           </article>
         </li> 
       {/each}

--- a/squadpage/src/routes/+page.svelte
+++ b/squadpage/src/routes/+page.svelte
@@ -29,7 +29,7 @@
         <li>
           <article class="card">
             <picture class="avatar">
-              <img src={member.avatar ? member.avatar : avatar } alt={`Avatar of ${member.name}`} width="130" height="auto" /> <!--standaard avatar als er geen avatar is --> 
+              <img src={member.avatar ? member.avatar : avatar } alt={member.avatar ? `Github avatar van ${member.name}` : `Standaard avatar voor ${member.name}`} width="130" /> 
             </picture>
               <a class="name" href={`/members/${member.id}`}>{member.name}</a>
           </article>

--- a/squadpage/src/routes/+page.svelte
+++ b/squadpage/src/routes/+page.svelte
@@ -17,10 +17,10 @@
 
   <nav class="squadpage-classes">
       <a href="/squad2e">
-          <img src={squad2e} alt="squad 2E icon" width="175" height="auto">
+          <img src={squad2e} alt="link naar de pagina van squad 2E" width="175" >
       </a>
       <a href="/squad2f">
-          <img src={squad2f} alt="squad 2F icon" width="175" height="auto">
+          <img src={squad2f} alt="link naar de pagina van squad 2F" width="175">
       </a>
     </nav>
 
@@ -45,6 +45,7 @@
       --text-color: black;
       --accent-color: #3b0764;
       --font-regular: 'Jacques Francois', sans-serif;
+      --font-size-menu: .75em;
       --font-size-xsmall: 1em;
       --font-size-small: 1.25em;
       --font-size-medium: 1.75em;
@@ -129,6 +130,12 @@
       align-items: center;
       gap: clamp(1rem, 2vw, 2rem);
       background-color: var(--background-color);
+    }
+
+    .squadpage-classes {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   
     .students-grid {


### PR DESCRIPTION

#### Wat is er veranderd in de commit?
- Alt attributen meer beschrijven geschreven. Hiervoor heb ik [deze](https://html.spec.whatwg.org/multipage/images.html#alt) bron gebruikt. 

#### Wat moet er gereviewd worden?

- [ ] Ben je het eens met de attributen? Sommige alt attributen heb ik na feedback bewust [leeg](https://github.com/Karima002/your-tribe-for-life-squad-page-s13/blob/7d041eb39ca0954f258654b16d03f6d7cd5d7e82/squadpage/src/lib/components/Header.svelte#L21) gelaten. De screenreader zou anders het woord 'menu' twee keer lezen.

#### Images
Geen.